### PR TITLE
Correction on EnableLog to make it work on Android and IOS

### DIFF
--- a/src/MultiLog4D.Base.pas
+++ b/src/MultiLog4D.Base.pas
@@ -65,8 +65,8 @@ type
         function EventID(const AEventID: UInt32): IMultiLog4D; virtual;
       {$ENDIF}
       function UserName(const AUserName: string): IMultiLog4D; virtual;
-      function EnableLog(const AEnable: Boolean = True): IMultiLog4D; virtual;
     {$ENDIF}
+    function EnableLog(const AEnable: Boolean = True): IMultiLog4D; virtual;
     function LogWrite(const AMsg: string; const ALogType: TLogType): IMultiLog4D; virtual; abstract;
     function LogWriteInformation(const AMsg: string): IMultiLog4D; virtual; abstract;
     function LogWriteWarning(const AMsg: string): IMultiLog4D; virtual; abstract;
@@ -131,12 +131,6 @@ begin
   Result := Self as IMultiLog4D;
 end;
 
-function TMultiLog4DBase.EnableLog(const AEnable: Boolean = True): IMultiLog4D;
-begin
-  FEnableLog := AEnable;
-  Result := Self as IMultiLog4D;
-end;
-
 {$IFDEF MSWINDOWS}
 function TMultiLog4DBase.Output(const AOutput: TLogOutputSet): IMultiLog4D;
 begin
@@ -163,6 +157,11 @@ begin
 end;
 {$ENDIF}
 {$ENDIF}
+function TMultiLog4DBase.EnableLog(const AEnable: Boolean = True): IMultiLog4D;
+begin
+  FEnableLog := AEnable;
+  Result := Self as IMultiLog4D;
+end;
 
 function TMultiLog4DBase.GetLogPrefix(const ALogType: TLogType): string;
 begin

--- a/src/MultiLog4D.Interfaces.pas
+++ b/src/MultiLog4D.Interfaces.pas
@@ -34,8 +34,8 @@ type
         function EventID(const AEventID: UInt32): IMultiLog4D;
       {$ENDIF}
       function UserName(const AUserName: string): IMultiLog4D;
-      function EnableLog(const AEnable: Boolean = True): IMultiLog4D;
     {$ENDIF}
+    function EnableLog(const AEnable: Boolean = True): IMultiLog4D;
     function LogWrite(const AMsg: string; const ALogType: TLogType): IMultiLog4D;
     function LogWriteInformation(const AMsg: string): IMultiLog4D;
     function LogWriteWarning(const AMsg: string): IMultiLog4D;

--- a/src/MultiLog4D.Util.pas
+++ b/src/MultiLog4D.Util.pas
@@ -28,8 +28,8 @@ type
     class procedure SetDateTimeFormat(const ADateTimeFormat: string); static;
     {$ENDIF}
     class procedure SetUserName(const AUserName: string); static;
-    class procedure SetEnableLog(const AEnableLog: Boolean = True); static;
     {$ENDIF}
+    class procedure SetEnableLog(const AEnableLog: Boolean = True); static;
   end;
 
 implementation
@@ -37,6 +37,7 @@ implementation
 class constructor TMultiLog4DUtil.Create;
 begin
   FLogger := TLogFactory.GetLogger;
+  SetEnableLog();
 end;
 
 class function TMultiLog4DUtil.Logger: IMultiLog4D;
@@ -83,13 +84,13 @@ begin
   if Assigned(FLogger) then
     FLogger.UserName(AUserName);
 end;
+{$ENDIF}
 
 class procedure TMultiLog4DUtil.SetEnableLog(const AEnableLog: Boolean = True);
 begin
   if Assigned(FLogger) then
     FLogger.EnableLog(AEnableLog);
 end;
-{$ENDIF}
 
 initialization
 TMultiLog4DUtil.Create;


### PR DESCRIPTION
MultiLog4D was not working nether Android nor IOS because EnableLog was included in the directive where nether Android nor IOS were defined, so this was keeping the MultiLog4D disabled on these platform.