### PR TITLE
Memory Leak fixes

### DIFF
--- a/src/MultiLog4D.Common.WriteToFile.pas
+++ b/src/MultiLog4D.Common.WriteToFile.pas
@@ -157,4 +157,13 @@ end;
 initialization
   TMultiLogWriteToFile.FInstance := nil;
 
+{$IFDEF MSWINDOWS}
+finalization
+if Assigned(TMultiLogWriteToFile.FInstance) then
+begin
+  TMultiLogWriteToFile.FInstance.Free;
+  TMultiLogWriteToFile.FInstance := nil;
+end;
+{$ENDIF}
+
 end.

--- a/src/MultiLog4D.Util.pas
+++ b/src/MultiLog4D.Util.pas
@@ -92,12 +92,19 @@ begin
     FLogger.EnableLog(AEnableLog);
 end;
 
+{$IFDEF MSWINDOWS}
+var
+  FMulti: TMultiLog4DUtil;
+{$ENDIF}
+
 initialization
-TMultiLog4DUtil.Create;
+{$IFDEF MSWINDOWS}FMulti := {$ENDIF}TMultiLog4DUtil.Create;
 
 finalization
+{$IFDEF MSWINDOWS}
+FMulti.Free;
+{$ELSE}
 TMultiLog4DUtil.FLogger := nil;
+{$ENDIF}
 
 end.
-
-


### PR DESCRIPTION
While running on Windows and SaveToFile configured, the following memory leaks were raising: 9 - 24 bytes: TMultiLogWriteToFile x 1 25 - 40 bytes: TMultiLog4DUtil x 1

I added the fixes only for Windows, since I didn't have time to try/test it on different platforms